### PR TITLE
Adding -t option to emr ssh command when using certificate for authentication

### DIFF
--- a/awscli/customizations/emr/ssh.py
+++ b/awscli/customizations/emr/ssh.py
@@ -91,7 +91,7 @@ class SSH(Command):
             command = ['ssh', '-o', 'StrictHostKeyChecking=no', '-o',
                        'ServerAliveInterval=10', '-i',
                        parsed_args.key_pair_file, constants.SSH_USER +
-                       '@' + master_dns]
+                       '@' + master_dns, '-t']
             if parsed_args.command:
                 command.append(parsed_args.command)
         else:


### PR DESCRIPTION
Cursor keys did not worked when running an interactive command with 'emr ssh' command like pig. This was because -t option was missing from the ssh command if authenticating with certificate although it was present when authenticating without certicate based on the code. 
I have added the -t option to ssh command when using certificate.
